### PR TITLE
CylinderCycleテーブルの導入と保持出力

### DIFF
--- a/Kdx.Contracts/DTOs/Cycle.cs
+++ b/Kdx.Contracts/DTOs/Cycle.cs
@@ -1,27 +1,26 @@
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 using Postgrest.Attributes;
 using Postgrest.Models;
 
 namespace Kdx.Contracts.DTOs
 {
-    [Postgrest.Attributes.Table("Cycle")]
+    [Table("Cycle")]
     public class Cycle : BaseModel
     {
         [PrimaryKey("Id")]
         [Postgrest.Attributes.Column("Id")]
         public int Id { get; set; }
-        
+
         [Postgrest.Attributes.Column("PlcId")]
         public int PlcId { get; set; }
-        
+
         [Postgrest.Attributes.Column("CycleName")]
         public string? CycleName { get; set; }
-        
+
         [Postgrest.Attributes.Column("StartDevice")]
         public string StartDevice { get; set; } = "L1000";
-        
+
         [Postgrest.Attributes.Column("ResetDevice")]
         public string ResetDevice { get; set; } = "L1001";
+
     }
 }

--- a/Kdx.Contracts/DTOs/Cylinder.cs
+++ b/Kdx.Contracts/DTOs/Cylinder.cs
@@ -34,8 +34,6 @@ namespace Kdx.Contracts.DTOs
         [Column("FlowType")]
         public string? FlowType { get; set; }
         [Column("ProcessStartCycle")]
-        public string? ProcessStartCycle { get; set; }
-        [Column("GoSensorCount")]
         public int? GoSensorCount { get; set; }
         [Column("BackSensorCount")]
         public int? BackSensorCount { get; set; }
@@ -45,8 +43,6 @@ namespace Kdx.Contracts.DTOs
         public string? RetentionSensorBack { get; set; }
         [Column("SortNumber")]
         public int? SortNumber { get; set; }
-        [Column("CycleId")]
-        public int? CycleId { get; set; }
         [Column("FlowCount")]
         public int? FlowCount { get; set; }
         [Column("ManualButton")]

--- a/Kdx.Contracts/DTOs/CylinderCycle.cs
+++ b/Kdx.Contracts/DTOs/CylinderCycle.cs
@@ -1,0 +1,20 @@
+using Postgrest.Attributes;
+using Postgrest.Models;
+
+namespace Kdx.Contracts.DTOs
+{
+    [Postgrest.Attributes.Table("CylinderCycle")]
+    public class CylinderCycle : BaseModel
+    {
+        [PrimaryKey("CylinderId")]
+        [Column("CylinderId")]
+        public int CylinderId { get; set; }
+
+        [Column("PlcId")]
+        public int PlcId { get; set; }
+
+        [PrimaryKey("CylinderId")]
+        [Column("CycleId")]
+        public int CycleId { get; set; }
+    }
+}

--- a/Kdx.Contracts/Interfaces/IAccessRepository.cs
+++ b/Kdx.Contracts/Interfaces/IAccessRepository.cs
@@ -34,6 +34,11 @@ namespace Kdx.Contracts.Interfaces
         List<Cycle> GetCycles();
 
         /// <summary>
+        /// 全てのサイクル情報を取得します。
+        /// </summary>
+        List<CylinderCycle>? GetCylinderCyclesByPlcId(int plcId);
+
+        /// <summary>
         /// 全ての工程情報を取得します。
         /// </summary>
         List<Process> GetProcesses();

--- a/Kdx.Infrastructure/Adapters/SupabaseRepositoryAdapter.cs
+++ b/Kdx.Infrastructure/Adapters/SupabaseRepositoryAdapter.cs
@@ -57,6 +57,11 @@ namespace Kdx.Infrastructure.Adapters
             return Task.Run(async () => await _supabaseRepository.GetCyclesAsync()).GetAwaiter().GetResult();
         }
 
+        public List<CylinderCycle> GetCylinderCyclesByPlcId(int plcId)
+        {
+            return Task.Run(async () => await _supabaseRepository.GetCylinderCyclesByPlcIdAsync(plcId)).GetAwaiter().GetResult();
+        }
+
         public List<Kdx.Contracts.DTOs.Process> GetProcesses()
         {
             return Task.Run(async () => await _supabaseRepository.GetProcessesAsync()).GetAwaiter().GetResult();

--- a/Kdx.Infrastructure/Repositories/ISupabaseRepository.cs
+++ b/Kdx.Infrastructure/Repositories/ISupabaseRepository.cs
@@ -29,6 +29,13 @@ namespace Kdx.Infrastructure.Repositories
         Task<List<Cycle>> GetCyclesAsync();
 
         /// <summary>
+        /// CylinderとCycleの中間テーブルをplcIdを元に取得します。
+        /// </summary>
+        /// <param name="plcId"></param>
+        /// <returns></returns>
+        Task<List<CylinderCycle>> GetCylinderCyclesByPlcIdAsync(int plcId);
+
+        /// <summary>
         /// 全ての工程情報を取得します。
         /// </summary>
         Task<List<Process>> GetProcessesAsync();

--- a/Kdx.Infrastructure/Repositories/SupabaseRepository.cs
+++ b/Kdx.Infrastructure/Repositories/SupabaseRepository.cs
@@ -101,6 +101,15 @@ namespace Kdx.Infrastructure.Repositories
             return response.Models;
         }
 
+        public async Task<List<CylinderCycle>> GetCylinderCyclesByPlcIdAsync(int plcId)
+        {
+            var response = await _supabaseClient
+                .From<CylinderCycle>()
+                .Where(c => c.PlcId == plcId)
+                .Get();
+            return response.Models;
+        }
+
         public async Task<List<Kdx.Contracts.DTOs.Process>> GetProcessesAsync()
         {
             var response = await _supabaseClient

--- a/KdxDesigner/Utils/Cylinder/BuildCylinderValve.cs
+++ b/KdxDesigner/Utils/Cylinder/BuildCylinderValve.cs
@@ -109,7 +109,7 @@ namespace KdxDesigner.Utils.Cylinder
             else
             {
                 result.AddRange(functions.OutputRetention());
-                result.AddRange(functions.Retention(sensors));
+                result.AddRange(functions.Retention(sensors, _mainViewModel.SelectedCycle!.StartDevice));
             }
 
             // マニュアル
@@ -124,12 +124,10 @@ namespace KdxDesigner.Utils.Cylinder
             if (cylinder.Cylinder.CYNameSub != null)
             {
                 result.AddRange(functions.SingleValve(sensors, cylinder.Cylinder.CYNameSub));
-
             }
             else
             {
                 result.AddRange(functions.SingleValve(sensors, null));
-
             }
 
             return result;
@@ -162,7 +160,6 @@ namespace KdxDesigner.Utils.Cylinder
             string cyName = cyNum + cyNumSub;                               // シリンダー名の組み合わせ  
 
             result.Add(LadderRow.AddStatement(id + ":" + cyName + " ダブルバルブ"));
-
             var label = cylinder.Mnemonic.DeviceLabel; // ラベルの取得  
             var startNum = cylinder.Mnemonic.StartNum; // ラベルの取得  
 
@@ -178,30 +175,24 @@ namespace KdxDesigner.Utils.Cylinder
             if (goOperation.Count != 0 && activeOperation.Count == 0)
             {
                 result.AddRange(functions.GoOperation(goOperation));
-                // 帰り方向自動指令
                 result.AddRange(functions.BackOperation(backOperation));
                 result.AddRange(functions.GoManualOperation(goOperation));
                 result.AddRange(functions.BackManualOperation(backOperation));
-
             }
             // 行き方向自動指令がない場合は、行き方向手動指令を使用
             else if (goOperation.Count == 0 && activeOperation.Count != 0)
             {
-
                 result.AddRange(functions.GoOperation(activeOperation));
-                // 帰り方向自動指令
                 result.AddRange(functions.BackOperation(backOperation));
                 result.AddRange(functions.GoManualOperation(activeOperation));
                 result.AddRange(functions.BackManualOperation(backOperation));
-
             }
 
+            // 励磁切指令
             if (offOperation.Count != 0)
             {
-                // 励磁切指令
                 result.AddRange(functions.OffOperation(offOperation));
             }
-
 
             result.AddRange(functions.ManualReset());
 
@@ -210,7 +201,7 @@ namespace KdxDesigner.Utils.Cylinder
 
             // 保持出力
             result.AddRange(functions.OutputRetention());
-            result.AddRange(functions.Retention(sensors));
+            result.AddRange(functions.Retention(sensors, _mainViewModel.SelectedCycle!.StartDevice));
 
             // マニュアル
             result.AddRange(functions.ManualButton());
@@ -324,7 +315,7 @@ namespace KdxDesigner.Utils.Cylinder
             else
             {
                 result.AddRange(functions.OutputRetention());
-                result.AddRange(functions.Retention(sensors));
+                result.AddRange(functions.Retention(sensors, _mainViewModel.SelectedCycle!.StartDevice));
             }
 
             // マニュアル

--- a/KdxDesigner/Utils/Cylinder/CylinderFunction.cs
+++ b/KdxDesigner/Utils/Cylinder/CylinderFunction.cs
@@ -170,7 +170,7 @@ namespace KdxDesigner.Utils.Cylinder
 
         public List<LadderCsvRow> OutputRetention()
         {
-            List<LadderCsvRow> result = new(); // 生成されるLadderCsvRowのリスト
+            List<LadderCsvRow> result = new();
 
             // 行き方向自動保持
             result.Add(LadderRow.AddLDP(_label + (_startNum + 0).ToString()));
@@ -193,24 +193,21 @@ namespace KdxDesigner.Utils.Cylinder
             result.Add(LadderRow.AddORP(SettingsManager.Settings.SoftResetSignal));
             result.Add(LadderRow.AddRST(_label + (_startNum + 6).ToString()));
 
-            return result; // 生成されたLadderCsvRowのリストを返す
+            return result;
         }
 
         public List<LadderCsvRow> CyclePulse()
         {
-            List<LadderCsvRow> result = new(); // 生成されるLadderCsvRowのリスト
+            List<LadderCsvRow> result = new();
+            var cylinderCycles = _mainViewModel._selectedCylinderCycles;
 
-            if (!string.IsNullOrWhiteSpace(_cylinder.Cylinder.ProcessStartCycle))
+            if (cylinderCycles != null
+                || cylinderCycles!.Count != 0)
             {
                 // ★ 1. Split と int.Parse を安全に行う
-                List<int> startCycles = _cylinder.Cylinder.ProcessStartCycle
-                    .Split(';', StringSplitOptions.RemoveEmptyEntries) // 空の要素を自動で削除
-                    .Select(idString =>
-                    {
-                        int.TryParse(idString.Trim(), out int id); // 空白を除去し、変換を試みる
-                        return id;
-                    })
-                    .Where(id => id != 0) // 変換に失敗した(0になった)要素を除外
+                List<int> startCycles = cylinderCycles
+                    .Where(cc => cc.CylinderId == _cylinder.Cylinder.Id) // 変換に失敗した(0になった)要素を除外
+                    .Select(cc => cc.CycleId)
                     .ToList();
 
                 // ★ 2. isFirst のロジックを foreach ループの外側で扱う方がシンプル
@@ -248,7 +245,7 @@ namespace KdxDesigner.Utils.Cylinder
 
         public List<LadderCsvRow> Excitation(List<IO> sensors)
         {
-            List<LadderCsvRow> result = new(); // 生成されるLadderCsvRowのリスト
+            List<LadderCsvRow> result = new();
             result.Add(LadderRow.AddLDI(_label + (_startNum + 0).ToString()));
             result.Add(LadderRow.AddANI(_label + (_startNum + 2).ToString()));
             result.Add(LadderRow.AddAND(_label + (_startNum + 5).ToString()));
@@ -259,10 +256,10 @@ namespace KdxDesigner.Utils.Cylinder
             result.Add(LadderRow.AddAND(_label + (_startNum + 6).ToString()));
             result.Add(LadderRow.AddOUT(_label + (_startNum + 20).ToString()));
 
-            return result; // 生成されたLadderCsvRowのリストを返す
+            return result;
         }
 
-        public List<LadderCsvRow> Retention(List<IO> sensors)
+        public List<LadderCsvRow> Retention(List<IO> sensors, string cycleDevice)
         {
             // ■■■ 1. ヘルパーメソッドを使って、Go/Backセンサーのアドレスリストをシンプルに取得 ■■■
             var goSensorAddresses = GetSensorAddresses(sensors, _cylinder.Cylinder.RetentionSensorGo, _cylinder.Cylinder.GoSensorCount, false); // isOutput: false
@@ -299,6 +296,7 @@ namespace KdxDesigner.Utils.Cylinder
                 }
             }
             result.Add(LadderRow.AddAND(_label + (_startNum + 5)));
+            result.Add(LadderRow.AddAND(cycleDevice));
             result.Add(LadderRow.AddOUT(_label + (_startNum + 19)));
 
 
@@ -329,6 +327,7 @@ namespace KdxDesigner.Utils.Cylinder
                 }
             }
             result.Add(LadderRow.AddAND(_label + (_startNum + 6)));
+            result.Add(LadderRow.AddAND(cycleDevice));
             result.Add(LadderRow.AddOUT(_label + (_startNum + 20)));
 
             // 行きチェック


### PR DESCRIPTION
## 概要
中間テーブルを導入して、複数CycleIdの正規化に対応。
その後保持出力をする際は自動運転中のみの条件を付加した。

## 関連Issue
Closes #(issue番号)

## 変更内容
- [x] 新機能の追加
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [ ] その他: 

## テスト
- [ ] 単体テストを追加/更新した
- [ ] 統合テストを追加/更新した
- [ ] 手動テストを実施した

### テスト内容
メモリテストと工程出力を実行。
テーブルの入力確認はそこまで。

## チェックリスト
- [x] コードがプロジェクトのコーディング規約に従っている
- [x] セルフレビューを実施した
- [x] コメントを適切に追加した（特に複雑な箇所）
- [ ] ドキュメントを更新した
- [ ] 変更により警告が増えていない
- [ ] 依存関係の追加がある場合、その理由を説明した
- [ ] Breaking changeがある場合、その影響を説明した

## スクリーンショット（UIの変更がある場合）
変更前後のスクリーンショットを添付してください。

### 変更前
<!-- スクリーンショットを添付 -->

### 変更後
<!-- スクリーンショットを添付 -->

## 追加情報
レビュアーに伝えたい追加情報があれば記載してください。

CylinderCycleテーブルの導入と保持出力